### PR TITLE
fix: enqueue race condition and simplify dispose checks

### DIFF
--- a/src/ChronoQueue/ChronoQueue.cs
+++ b/src/ChronoQueue/ChronoQueue.cs
@@ -52,8 +52,8 @@ public sealed class ChronoQueue<T> : IChronoQueue<T>, IDisposable
             throw new ChronoQueueItemExpiredException("The item has already expired and cannot be enqueued.");
 
         var id = Interlocked.Increment(ref _idCounter.Value);
-        _queue.Enqueue(id);
         _items.TryAdd(id, item);
+        _queue.Enqueue(id);
         Interlocked.Increment(ref _count.Value);
     }
 
@@ -171,7 +171,7 @@ public sealed class ChronoQueue<T> : IChronoQueue<T>, IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static bool DisposeOnExpiry(ChronoQueueItem<T> item)
     {
-        if (item.DisposeOnExpiry && item.IsExpired() && item is { DisposeOnExpiry: true, Item: IDisposable disposableItem })
+        if (item.IsExpired() && item is { DisposeOnExpiry: true, Item: IDisposable disposableItem })
         {
             disposableItem.Dispose();
             return true;
@@ -182,7 +182,7 @@ public sealed class ChronoQueue<T> : IChronoQueue<T>, IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static bool DisposeOnFlush(ChronoQueueItem<T> item)
     {
-        if (item.DisposeOnFlush && item is { DisposeOnFlush: true, Item: IDisposable disposableItem })
+        if (item is { DisposeOnFlush: true, Item: IDisposable disposableItem })
         {
             disposableItem.Dispose();
             return true;

--- a/test/ChronoQueueUnitTests/ChronoQueueTests.cs
+++ b/test/ChronoQueueUnitTests/ChronoQueueTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using ChronoQueue;
 using Shouldly;
 
@@ -22,7 +23,7 @@ public class ChronoQueueTests
         result.ShouldBe("test1");
         queue.Count().ShouldBe(0);
     }
-    
+
     [Fact]
     public async Task Enqueue_Item_Should_Expire_After_Lifetime()
     {
@@ -39,7 +40,7 @@ public class ChronoQueueTests
         queue.Count().ShouldBe(0);
         result.ShouldBeNull();
     }
-    
+
     [Fact]
     public void Dequeue_On_EmptyQueue_Should_Return_False()
     {
@@ -48,10 +49,11 @@ public class ChronoQueueTests
         var success = queue.TryDequeue(out var result);
 
         success.ShouldBeFalse();
-        result.ShouldBeNull();;
+        result.ShouldBeNull();
+        ;
         queue.Count().ShouldBe(0);
     }
-    
+
     [Fact]
     public void Enqueue_Then_Flush_Should_Return_Empty_Queue()
     {
@@ -66,7 +68,7 @@ public class ChronoQueueTests
         queue.Flush();
         queue.Count().ShouldBe(0);
     }
-    
+
     [Fact]
     public async Task Enqueue_ExpiredItem_Then_Should_Throw_ChronoQueueItemExpiredException()
     {
@@ -74,10 +76,11 @@ public class ChronoQueueTests
         var expiryTime = DateTime.UtcNow.AddSeconds(1);
         var item = new ChronoQueueItem<string>("test1", expiryTime);
         await Task.Delay(1000);
-        Should.Throw<ChronoQueueItemExpiredException>(() => queue.Enqueue(new ChronoQueueItem<string>("test1", DateTime.UtcNow.AddSeconds(-1))));
+        Should.Throw<ChronoQueueItemExpiredException>(() =>
+            queue.Enqueue(new ChronoQueueItem<string>("test1", DateTime.UtcNow.AddSeconds(-1))));
         Should.Throw<ChronoQueueItemExpiredException>(() => queue.Enqueue(item));
     }
-    
+
     [Fact]
     public async Task Enqueue_With_DisposeOnExpiry_Expired_Item_After_Lifetime_Dispose_Should_Be_Called()
     {
@@ -95,28 +98,84 @@ public class ChronoQueueTests
         queue.Count().ShouldBe(0);
         result.ShouldBeNull();
         Should.Throw<ObjectDisposedException>(() => q.Dispose());
-        
+
         var item2 = new ChronoQueueItem<AwesomeClass>(new AwesomeClass(), DateTime.UtcNow.AddMilliseconds(100), true);
         await Task.Delay(200);
         ChronoQueue<AwesomeClass>.DisposeOnExpiry(item2).ShouldBeTrue();
     }
-    
+
     [Fact]
     public void Flush_With_DisposeOnFlush_Item_Dispose_Should_Be_Called()
     {
         var q = new AwesomeClass();
         using var queue = new ChronoQueue<AwesomeClass>();
         var item = new ChronoQueueItem<AwesomeClass>(q, DateTime.UtcNow.AddMilliseconds(1000), false, true);
-        
+
         queue.Enqueue(item);
         queue.Count().ShouldBe(1);
         queue.Flush();
         Should.Throw<ObjectDisposedException>(() => q.Dispose());
-        
-        var item2 = new ChronoQueueItem<AwesomeClass>(new AwesomeClass(), DateTime.UtcNow.AddMilliseconds(1000), false, true);
+
+        var item2 = new ChronoQueueItem<AwesomeClass>(new AwesomeClass(), DateTime.UtcNow.AddMilliseconds(1000), false,
+            true);
         ChronoQueue<AwesomeClass>.DisposeOnFlush(item2).ShouldBeTrue();
     }
+
+    [Theory]
+    [InlineData(4, 50_000, 5)] // 4 producers, 50k items each, 5 iterations
+    [InlineData(2, 100_000, 3)] // 2 producers, 100k items each, 3 iterations
+    public async Task Enqueue_Dequeue_ShouldNotLoseItems_UnderConcurrency(
+        int producerCount,
+        int itemsPerProducer,
+        int iterations)
+    {
+        for (int iteration = 0; iteration < iterations; iteration++)
+        {
+            var queue = new ChronoQueue<int>();
+            var totalItems = producerCount * itemsPerProducer;
+            var produced = new ConcurrentBag<int>();
+            var consumed = new ConcurrentBag<int>();
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+
+            // Start producers
+            var producers = Enumerable.Range(0, producerCount)
+                .Select(_ => Task.Run(() =>
+                {
+                    for (var i = 0; i < itemsPerProducer; i++)
+                    {
+                        var item = new ChronoQueueItem<int>(i, DateTime.UtcNow.AddSeconds(10), true);
+                        queue.Enqueue(item);
+                        produced.Add(item.Item);
+                    }
+                }, cts.Token))
+                .ToArray();
+
+            // Start consumer
+            var consumer = Task.Run(() =>
+            {
+                while (!cts.IsCancellationRequested && consumed.Count < totalItems)
+                {
+                    if (queue.TryDequeue(out var item))
+                    {
+                        consumed.Add(item);
+                    }
+                    else
+                    {
+                        Thread.Yield();
+                    }
+                }
+            }, cts.Token);
+
+            await Task.WhenAll(Task.WhenAll(producers), consumer);
+
+            // Assert: no items were lost
+            Assert.Equal(totalItems, produced.Count);
+            Assert.Equal(totalItems, consumed.Count);
+            Assert.Empty(produced.Except(consumed));
+        }
+    }
 }
+
 
 class AwesomeClass : IDisposable
 {

--- a/test/ChronoQueueUnitTests/ChronoQueueTests.cs
+++ b/test/ChronoQueueUnitTests/ChronoQueueTests.cs
@@ -169,9 +169,9 @@ public class ChronoQueueTests
             await Task.WhenAll(Task.WhenAll(producers), consumer);
 
             // Assert: no items were lost
-            Assert.Equal(totalItems, produced.Count);
-            Assert.Equal(totalItems, consumed.Count);
-            Assert.Empty(produced.Except(consumed));
+            produced.Count.ShouldBe(totalItems, $"Iteration {iteration}: All produced items should be counted");
+            consumed.Count.ShouldBe(totalItems, $"Iteration {iteration}: All consumed items should be counted");
+            produced.Except(consumed).ShouldBeEmpty($"Iteration {iteration}: No items should be lost in the queue");
         }
     }
 }


### PR DESCRIPTION
- Changed Enqueue ordering so that `_items.TryAdd` is performed before `_queue.Enqueue`. This prevents a race where `TryDequeue` could consume an ID not yet present in `_items`, causing the item to be lost.

- Simplified `DisposeOnExpiry` and `DisposeOnFlush` by removing redundant property checks and using direct `is IDisposable` pattern matching.

- Update unit tests
 